### PR TITLE
Fix ElvUI version fetching and change it to use the master branch

### DIFF
--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -238,11 +238,12 @@ def tukui(addonpage):
 
 
 def getTukuiVersion(addonpage):
+    addonpage = addonpage + '/tree/master'
     try:
         response = requests.get(addonpage)
         response.raise_for_status()   # Raise an exception for HTTP errors
         content = str(response.content)
-        match = re.search(r'<div class="commit-sha-group">\\n<div class="label label-monospace">\\n(?P<hash>[^<]+?)\\n</div>', content)
+        match = re.search(r'<div class="commit-sha-group d-none d-sm-flex">\\n<div class="label label-monospace">\\n(?P<hash>[^<]+?)\\n</div>', content)
         result = ''
         if match:
             result = match.group('hash')


### PR DESCRIPTION
A recent GitLab update broke the regex search. After fixing it I discovered that while the master branch is used to update ElvUI, the hash used for checking for a new release is fetched from the development branch, causing the script to download and reinstall what is probably the currently installed version almost every time the script is run.